### PR TITLE
added sphinx_togglebutton + fixed version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
-jupyter-book
-sphinx-autobuild
-sphinxcontrib-mermaid
-matplotlib
-numpy
+jupyter-book==2.0.2
+sphinx-autobuild==2025.8.25
+sphinxcontrib-mermaid==1.0.0
+matplotlib==3.10.7
+numpy==2.3.4
+sphinx_togglebutton==0.3.2


### PR DESCRIPTION
This pull request adds the sphinx-togglebutton extension to improve documentation interactivity and pins version numbers for other dependencies to ensure consistent builds across environments.

Changes include:

- Added sphinx-togglebutton to docs/requirements.txt
- Specified version constraints for existing libraries
- Verified successful build with updated dependencies (locally)