### PR TITLE
small cometic change to structsense documentation: heading/subheading levels 

### DIFF
--- a/docs/structsense_configuration.md
+++ b/docs/structsense_configuration.md
@@ -1,5 +1,6 @@
 <!-- Configuration Overview & Template -->
-# Configuration Overview & Template
+# Setup Configuration 
+## Configuration Overview & Template
 
 StructSense is configured with **environment variables** and a **YAML config**.  
 Pass the YAML via CLI, e.g. `--config config/ner_agent.yaml`.
@@ -18,7 +19,7 @@ Pass the YAML via CLI, e.g. `--config config/ner_agent.yaml`.
 A blank template is available in `config_template/`. See **Templates**.
 
 <!--Agent Configuration -->
-# Agent Configuration
+## Agent Configuration
 
 These agent IDs are required and must not be renamed:
 - `extractor_agent`
@@ -43,7 +44,7 @@ agent_config:
       base_url: https://openrouter.ai/api/v1
 ```
 
-## Using Ollama (Local Models)
+### Using Ollama (Local Models)
 ```yaml
 agent_config:
   extractor_agent:
@@ -66,7 +67,7 @@ structsense-cli extract \
 ```
 
 <!-- Task Configuration -->
-# Task Configuration
+## Task Configuration
 
 Required task IDs (do not rename):
 - `extraction_task`
@@ -93,9 +94,9 @@ task_config:
 ```
 
 <!-- Embeddings & Knowledge -->
-# Embeddings & Knowledge
+## Embeddings & Knowledge
 
-## Embedding Configuration
+### Embedding Configuration
 ```yaml
 embedder_config:
   provider: ollama
@@ -104,13 +105,13 @@ embedder_config:
     model: nomic-embed-text:latest
 ```
 
-## Knowledge Source (Vector DB)
+### Knowledge Source (Vector DB)
 `WEAVIATE_*` environment variables are optional and only needed if you enable a knowledge source for schema/ontology lookup.
 
 <!-- Environment Variables -->
-# Environment Variables
+## Environment Variables
 
-## Core
+### Core
 | Variable | Description | Default |
 |---|---|---|
 | `ENABLE_KG_SOURCE` | Enable vector DB knowledge source | `false` |
@@ -118,7 +119,7 @@ embedder_config:
 
 > **Note:** `WEAVIATE_API_KEY` is required if you enable the knowledge source.
 
-## Weaviate (optional)
+### Weaviate (optional)
 | Variable | Description | Default |
 |---|---|---|
 | `WEAVIATE_HTTP_HOST` | HTTP host | `localhost` |
@@ -128,14 +129,14 @@ embedder_config:
 | `WEAVIATE_GRPC_PORT` | gRPC port | `50051` |
 | `WEAVIATE_GRPC_SECURE` | Use secure gRPC | `false` |
 
-## Weaviate Timeouts
+### Weaviate Timeouts
 | Variable | Description | Default |
 |---|---|---|
 | `WEAVIATE_TIMEOUT_INIT` | Initialization timeout (s) | `30` |
 | `WEAVIATE_TIMEOUT_QUERY` | Query timeout (s) | `60` |
 | `WEAVIATE_TIMEOUT_INSERT` | Insert timeout (s) | `120` |
 
-## Ollama for Weaviate
+### Ollama for Weaviate
 | Variable | Description | Default |
 |---|---|---|
 | `OLLAMA_API_ENDPOINT` | Ollama API endpoint | `http://host.docker.internal:11434` |
@@ -144,21 +145,21 @@ embedder_config:
 > If Ollama runs on host and Weaviate in Docker, use `http://host.docker.internal:11434`.  
 > If both are in Docker on the same host network, use `http://localhost:11434`.
 
-## Experiment Tracking (optional)
+### Experiment Tracking (optional)
 | Variable | Description | Default |
 |---|---|---|
 | `ENABLE_WEIGHTSANDBIAS` | Enable W&B | `false` |
 | `ENABLE_MLFLOW` | Enable MLflow | `false` |
 | `MLFLOW_TRACKING_URL` | MLflow tracking URL | `http://localhost:5000` |
 
-## Minimal (no tracking, no knowledge source)
+### Minimal (no tracking, no knowledge source)
 ```bash
 ENABLE_WEIGHTSANDBIAS=false
 ENABLE_MLFLOW=false
 ENABLE_KG_SOURCE=false
 ```
 
-## Example `.env`
+### Example `.env`
 ```bash
 WEAVIATE_API_KEY=your_api_key
 WEAVIATE_HTTP_HOST=localhost

--- a/docs/structsense_examples.md
+++ b/docs/structsense_examples.md
@@ -7,7 +7,7 @@
 - Entity and relation extraction from text
 - Knowledge graph construction
 
-# Blank Configuration Template
+## Blank Configuration Template
 
 A starting template is provided in `config_template/`.
 

--- a/docs/structsense_getting_started.md
+++ b/docs/structsense_getting_started.md
@@ -15,7 +15,7 @@ pip install -e .
 #### Python Version
 StructSense supports **Python >=3.10,<3.13**.
 
-### Optional Services
+## Optional Services
 - **Grobid** (PDF parsing)
 - **Weaviate** (vector database for knowledge/ontology)
 - **Ollama** (local LLM/embedding provider)

--- a/docs/structsense_getting_started.md
+++ b/docs/structsense_getting_started.md
@@ -12,7 +12,7 @@ git clone https://github.com/sensein/structsense.git
 cd structsense
 pip install -e .
 ```
-#### Python Version
+### Python Version
 StructSense supports **Python >=3.10,<3.13**.
 
 ## Optional Services

--- a/docs/structsense_getting_started.md
+++ b/docs/structsense_getting_started.md
@@ -1,5 +1,6 @@
+# Getting Started
 <!-- # Installation-->
-# Installation
+## Installation
 You can install the latest version of StructSense directly from PyPI using pip:
 ```bash
 pip install structsense
@@ -11,34 +12,34 @@ git clone https://github.com/sensein/structsense.git
 cd structsense
 pip install -e .
 ```
-### Python Version
+#### Python Version
 StructSense supports **Python >=3.10,<3.13**.
 
-## Optional Services
+### Optional Services
 - **Grobid** (PDF parsing)
 - **Weaviate** (vector database for knowledge/ontology)
 - **Ollama** (local LLM/embedding provider)
 - **MLflow / Weights & Biases** (experiment tracking)
 
 <!-- # Requirements -->
-# Requirements
-## PDF Extraction (Grobid)
+## Requirements
+### PDF Extraction (Grobid)
 
 By default StructSense uses a **local Grobid** service. If Grobid is running locally, no extra setup is needed.
 
-### Run Grobid with Docker
+#### Run Grobid with Docker
 ```bash
 docker pull lfoppiano/grobid:0.8.0
 docker run --init -p 8070:8070 -e JAVA_OPTS="-XX:+UseZGC" lfoppiano/grobid:0.8.0
 ```
 `JAVA_OPTS="-XX:+UseZGC"` helps avoid a macOS-specific error.
 
-### Remote Grobid
+#### Remote Grobid
 ```bash
 export GROBID_SERVER_URL_OR_EXTERNAL_SERVICE=http://your-remote-grobid:PORT
 ```
 
-## External PDF Extraction API
+### External PDF Extraction API
 If using a non‑Grobid API:
 ```bash
 export GROBID_SERVER_URL_OR_EXTERNAL_SERVICE=https://api.SOMEAPIENDPOINT.com/api/extract
@@ -48,9 +49,9 @@ export EXTERNAL_PDF_EXTRACTION_SERVICE=True
 
 <!--Running -->
 
-# Running
+## Running
 
-## Using OpenRouter
+### Using OpenRouter
 ```bash
 structsense-cli extract \
   --source somefile.pdf \
@@ -60,7 +61,7 @@ structsense-cli extract \
   --save_file result.json  # optional
 ```
 
-## Using Ollama (Local)
+### Using Ollama (Local)
 ```bash
 structsense-cli extract \
   --source somefile.pdf \
@@ -69,14 +70,14 @@ structsense-cli extract \
   --save_file result.json  # optional
 ```
 
-### Chunking
+#### Chunking
 Disabled by default. Enable with:
 ```bash
 --chunking True
 ```
 
 <!-- Docker -->
-# Docker
+## Docker
 
 The `docker/` directory contains compose files (individual and merged) to run:
 - **Grobid**

--- a/docs/structsense_getting_started.md
+++ b/docs/structsense_getting_started.md
@@ -70,7 +70,7 @@ structsense-cli extract \
   --save_file result.json  # optional
 ```
 
-#### Chunking
+### Chunking
 Disabled by default. Enable with:
 ```bash
 --chunking True

--- a/docs/structsense_overview.md
+++ b/docs/structsense_overview.md
@@ -1,4 +1,4 @@
-# 🧩 StructSense
+# Overview
 
 **StructSense** is a multi‑agent system that extracts **structured information** from unstructured sources like PDFs and scientific text.  
 It orchestrates specialized agents to collaborate, align to schemas/ontologies, and emit JSON outputs suitable for knowledge graphs and downstream analytics.

--- a/docs/structsense_troubleshooting.md
+++ b/docs/structsense_troubleshooting.md
@@ -1,7 +1,8 @@
 <!-- # Known Issues & Troubleshooting-->
-# Known Issues & Troubleshooting
+# Troubleshooting and FAQ
+## Known Issues and Troubleshooting
 
-## pip “resolution-too-deep”
+### pip “resolution-too-deep”
 **Symptom**
 - During installation, `pip` backtracks across many `opentelemetry-*` packages and fails.
 
@@ -19,7 +20,7 @@ ERROR: No matching distribution found for structsense
 Ensure Python version is **>=3.10,<3.13**.
 
 <!-- FAQ -->
-# FAQ
+## FAQ
 
 **Q: Do I need Weaviate to run StructSense?**  
 A: No. Set `ENABLE_KG_SOURCE=false` to run without a vector DB.


### PR DESCRIPTION
- changed '#' to '##' to resolve numbering issue, now each .md has only one main header (#)