### PR TITLE
Add Epic 08: Neuroscience Abstract Atlas

### DIFF
--- a/design/brainkb-architecture.md
+++ b/design/brainkb-architecture.md
@@ -1192,7 +1192,6 @@ The abstract atlas is a meta-scientific layer over publication corpora — paper
 | 06 Automated Ingestion Pipeline | L2, L3, L4 | Auth, ingest | Service credentials, idempotent atlas/package jobs, file manifests, validation reports, graph diff, atomic activation. |
 | 07 Cross-KB Federated Query | L0, L2, L3, L4 | Federation, search, cache lookup | Query planning, atlas/archive/publication/gene connectors, connector/result cache, source attribution, partial results, URI reconciliation. |
 | 08 Neuroscience Abstract Atlas | L0, L1, L2, L3, L4, L5 | Search, drill-down, LLM-assisted query | Corpus ingest with DOI/OpenAlex/ORCID linkage, configurable embedding backends, UMAP and community-detection clustering, cluster labeling, landscape UI with lens switching, atlas release manifests, [Future] citation/trend/gap overlays and MCP endpoint. |
-| 09 Grounded Assistant | L1, L2, L3, L4 | LLM-assisted query, search, memory retrieval | pgvector retrieval, cache-aware graph hydration, scoped memory, citations to claims/assets/papers, provider boundary, fallback behavior. |
 
 ## Contract Traceability Matrix
 

--- a/design/brainkb-architecture.md
+++ b/design/brainkb-architecture.md
@@ -66,6 +66,7 @@ Each use case corresponds to an epic in the [Epic User Stories](#epic-user-stori
 | 05 | "Answer in plain English — and expose the graph to any tool that asks." | Researcher, external agent or tool | [Epic 05](#epic-05---grounded-assistant--mcp-interface) |
 | 06 | "A partner KB published a new release. Pull it in." | Ingest pipeline, partner release bot | [Epic 06](#epic-06---automated-ingestion-pipeline) |
 | 07 | "Combine evidence from three sources, in one query." | Researcher | [Epic 07](#epic-07---cross-kb-federated-query) |
+| 08 | "Where does this paper sit in the field — and what are the active themes, trends, and gaps?" | Researcher | [Epic 08](#epic-08---neuroscience-abstract-atlas) |
 
 ---
 
@@ -896,6 +897,7 @@ Epics:
 5. [Grounded Assistant / MCP Interface](#epic-05---grounded-assistant--mcp-interface)
 6. [Automated Ingestion Pipeline](#epic-06---automated-ingestion-pipeline)
 7. [Cross-KB Federated Query](#epic-07---cross-kb-federated-query)
+8. [Neuroscience Abstract Atlas](#epic-08---neuroscience-abstract-atlas)
 
 ### Epic 01 - Entity Exploration and Knowledge Review
 
@@ -1130,6 +1132,52 @@ Resources are tangible things with identifiers — datasets, tools, models, pipe
 3. [Future] Add timeout, partial result, and stale cache behavior so external failures are visible.
 4. [Future] Generalize query planning across heterogeneous SPARQL, REST, and file sources.
 
+### Epic 08 - Neuroscience Abstract Atlas
+
+The abstract atlas is a meta-scientific layer over publication corpora — papers, preprints, and conference abstracts — that complements the entity graph with a topical map of how the field is organized. It is informed by the [sensein/ohbm2026](https://github.com/sensein/ohbm2026) pipeline (conference-scale corpus, embeddings, UMAP, community-detection clusters, faceted UI) and by [Costa et al., *The Evolving Landscape of Neuroscience*](https://apertureneuro.org/article/156380-the-evolving-landscape-of-neuroscience) (field-scale longitudinal map of ~460k PubMed abstracts, contrastive-learned embedding space, Leiden clusters, citation overlays).
+
+**Actor:** researcher
+
+**Goal:** see where a paper, preprint, or claim sits in the topical landscape of a corpus, and discover active themes, emerging trends, and underrepresented gaps across the field.
+
+**Value:** entity exploration (Epic 01) answers "what do we know about *this thing*"; the abstract atlas answers "what does the field *look like*". Cluster maps reveal active themes, cross-cluster relationships, and missing intersections that a per-entity view cannot expose, and ground the rest of BrainKB (search ranking, hypothesis suggestions, grounded answers) in the structure of the literature.
+
+**Trigger:** a researcher opens a corpus landscape (a conference, a journal feed, or a curated set), drops in a query or a specific paper, or asks "what does the field look like here?" An external agent may also request cluster context for a paper or query via MCP.
+
+**Preconditions:**
+
+- A corpus of papers, preprints, or conference abstracts is ingested with stable identifiers (DOI, OpenAlex ID, or local IRI) and normalized title/abstract/section text.
+- Author and institution metadata is reconciled against external IDs (ORCID, ROR) where available.
+- Embedding generation is available with a configurable backend; embeddings are persisted with the corpus release.
+- Dimensionality reduction (e.g., UMAP) and clustering (community detection and k-means) run as offline workflows producing reproducible artifacts with checkpointed, resumable execution.
+- Cluster outputs carry human-readable labels derived from member text and link back to canonical entity pages in the graph.
+- [Future] Claim-level embeddings exist alongside abstract-level embeddings so multiple semantic lenses can be overlaid on the same corpus.
+- [Future] Citation and cross-reference data (OpenAlex, PubMed) is available for inter-cluster relationship and influence analysis.
+- [Future] Atlas artifacts are versioned with the underlying graph release so a landscape view can be reproduced as-of a given date.
+
+**Acceptance criteria:**
+
+- Researchers can browse an interactive 2D landscape projection of a corpus, colored by cluster, with hover, zoom, and select.
+- Lexical and semantic search both work over the corpus and return results with their cluster assignments.
+- Each paper, preprint, or abstract page shows its cluster assignment(s), nearest neighbours, and links into the entity graph (claims, datasets, authors).
+- Cluster pages list member abstracts, top terms, and a human-readable cluster label.
+- The corpus, embedding model, reduction parameters, and cluster artifacts are recorded in a release manifest so a landscape can be re-derived identically.
+- [Future] Researchers can switch between semantic lenses (e.g., title+abstract embedding vs. claim-level embedding) over the same corpus.
+- [Future] Longitudinal views surface cluster size, growth rate, and citation interactions over time.
+- [Future] Gap analysis highlights underrepresented intersections (e.g., methodology × scale pairs that are absent or sparse).
+- [Future] An MCP endpoint returns cluster lookups, nearest neighbours, and corpus coordinates so external tools and the grounded assistant can use landscape context.
+
+**Implementation sequencing:**
+
+1. Ingest a seed corpus — OHBM 2026 abstracts as the first fixture — with normalized title/abstract/section text, figures linked as evidence, and author/institution reconciliation against ORCID/ROR/OpenAlex.
+2. Generate abstract-level embeddings via a configurable backend (e.g., MiniLM, OpenAI, Voyage) and persist them with the corpus release manifest.
+3. Run UMAP plus community-detection (Leiden) and k-means clustering; produce labelled clusters and an interactive landscape view with lexical and semantic search, faceted browse, and cluster pages.
+4. Link landscape entries back to the entity graph so claims, datasets, and authors discovered in BrainKB align with their landscape position.
+5. [Future] Add claim-level extraction and a second semantic lens over the same corpus so atlases can be compared across lenses.
+6. [Future] Extend ingestion to a longitudinal corpus (e.g., PubMed-derived neuroscience subset following the Aperture Neuro methodology) for field-scale trend and gap analysis.
+7. [Future] Add citation network overlays, cluster-size time series, and gap analyses with as-of versioning tied to graph releases.
+8. [Future] Expose the atlas through an MCP endpoint and feed cluster context into grounded-assistant retrieval so answers can cite a paper's topical neighbourhood as well as its claims.
+
 ## Traceability Matrix
 
 > **TODO:** Review "Primary architecture levels" for all epics once L3 (Service Dependencies), L4 (Deployment), and L5 (Knowledge/Data Model) diagrams are complete. L5 is currently missing from all rows and several assignments may need updating.
@@ -1143,6 +1191,7 @@ Resources are tangible things with identifiers — datasets, tools, models, pipe
 | 05 Grounded Assistant / MCP Interface | L1, L2, L3, L4 | LLM-assisted query, search, memory retrieval | MCP interface, pgvector retrieval, cache-aware graph hydration, citations to claims/assets/papers, provider boundary. |
 | 06 Automated Ingestion Pipeline | L2, L3, L4 | Auth, ingest | Service credentials, idempotent atlas/package jobs, file manifests, validation reports, graph diff, atomic activation. |
 | 07 Cross-KB Federated Query | L0, L2, L3, L4 | Federation, search, cache lookup | Query planning, atlas/archive/publication/gene connectors, connector/result cache, source attribution, partial results, URI reconciliation. |
+| 08 Neuroscience Abstract Atlas | L0, L1, L2, L3, L4, L5 | Search, drill-down, LLM-assisted query | Corpus ingest with DOI/OpenAlex/ORCID linkage, configurable embedding backends, UMAP and community-detection clustering, cluster labelling, landscape UI with lens switching, atlas release manifests, [Future] citation/trend/gap overlays and MCP endpoint. |
 | 09 Grounded Assistant | L1, L2, L3, L4 | LLM-assisted query, search, memory retrieval | pgvector retrieval, cache-aware graph hydration, scoped memory, citations to claims/assets/papers, provider boundary, fallback behavior. |
 
 ## Contract Traceability Matrix

--- a/design/brainkb-architecture.md
+++ b/design/brainkb-architecture.md
@@ -1149,7 +1149,7 @@ The abstract atlas is a meta-scientific layer over publication corpora — paper
 - A corpus of papers, preprints, or conference abstracts is ingested with stable identifiers (DOI, OpenAlex ID, or local IRI) and normalized title/abstract/section text.
 - Author and institution metadata is reconciled against external IDs (ORCID, ROR) where available.
 - Embedding generation is available with a configurable backend; embeddings are persisted with the corpus release.
-- Dimensionality reduction (e.g., UMAP) and clustering (community detection and k-means) run as offline workflows producing reproducible artifacts with checkpointed, resumable execution.
+- Dimensionality reduction (e.g., UMAP) and clustering (community-detection and k-means) run as offline workflows producing reproducible artifacts with checkpointed, resumable execution.
 - Cluster outputs carry human-readable labels derived from member text and link back to canonical entity pages in the graph.
 - [Future] Claim-level embeddings exist alongside abstract-level embeddings so multiple semantic lenses can be overlaid on the same corpus.
 - [Future] Citation and cross-reference data (OpenAlex, PubMed) is available for inter-cluster relationship and influence analysis.
@@ -1159,24 +1159,24 @@ The abstract atlas is a meta-scientific layer over publication corpora — paper
 
 - Researchers can browse an interactive 2D landscape projection of a corpus, colored by cluster, with hover, zoom, and select.
 - Lexical and semantic search both work over the corpus and return results with their cluster assignments.
-- Each paper, preprint, or abstract page shows its cluster assignment(s), nearest neighbours, and links into the entity graph (claims, datasets, authors).
+- Each paper, preprint, or abstract page shows its cluster assignment(s), nearest neighbors, and links into the entity graph (claims, datasets, authors).
 - Cluster pages list member abstracts, top terms, and a human-readable cluster label.
 - The corpus, embedding model, reduction parameters, and cluster artifacts are recorded in a release manifest so a landscape can be re-derived identically.
 - [Future] Researchers can switch between semantic lenses (e.g., title+abstract embedding vs. claim-level embedding) over the same corpus.
 - [Future] Longitudinal views surface cluster size, growth rate, and citation interactions over time.
 - [Future] Gap analysis highlights underrepresented intersections (e.g., methodology × scale pairs that are absent or sparse).
-- [Future] An MCP endpoint returns cluster lookups, nearest neighbours, and corpus coordinates so external tools and the grounded assistant can use landscape context.
+- [Future] An MCP endpoint returns cluster lookups, nearest neighbors, and corpus coordinates so external tools and the grounded assistant can use landscape context.
 
 **Implementation sequencing:**
 
 1. Ingest a seed corpus — OHBM 2026 abstracts as the first fixture — with normalized title/abstract/section text, figures linked as evidence, and author/institution reconciliation against ORCID/ROR/OpenAlex.
 2. Generate abstract-level embeddings via a configurable backend (e.g., MiniLM, OpenAI, Voyage) and persist them with the corpus release manifest.
-3. Run UMAP plus community-detection (Leiden) and k-means clustering; produce labelled clusters and an interactive landscape view with lexical and semantic search, faceted browse, and cluster pages.
+3. Run UMAP plus community-detection (Leiden) and k-means clustering; produce labeled clusters and an interactive landscape view with lexical and semantic search, faceted browse, and cluster pages.
 4. Link landscape entries back to the entity graph so claims, datasets, and authors discovered in BrainKB align with their landscape position.
 5. [Future] Add claim-level extraction and a second semantic lens over the same corpus so atlases can be compared across lenses.
 6. [Future] Extend ingestion to a longitudinal corpus (e.g., PubMed-derived neuroscience subset following the Aperture Neuro methodology) for field-scale trend and gap analysis.
 7. [Future] Add citation network overlays, cluster-size time series, and gap analyses with as-of versioning tied to graph releases.
-8. [Future] Expose the atlas through an MCP endpoint and feed cluster context into grounded-assistant retrieval so answers can cite a paper's topical neighbourhood as well as its claims.
+8. [Future] Expose the atlas through an MCP endpoint and feed cluster context into grounded-assistant retrieval so answers can cite a paper's topical neighborhood as well as its claims.
 
 ## Traceability Matrix
 
@@ -1191,7 +1191,7 @@ The abstract atlas is a meta-scientific layer over publication corpora — paper
 | 05 Grounded Assistant / MCP Interface | L1, L2, L3, L4 | LLM-assisted query, search, memory retrieval | MCP interface, pgvector retrieval, cache-aware graph hydration, citations to claims/assets/papers, provider boundary. |
 | 06 Automated Ingestion Pipeline | L2, L3, L4 | Auth, ingest | Service credentials, idempotent atlas/package jobs, file manifests, validation reports, graph diff, atomic activation. |
 | 07 Cross-KB Federated Query | L0, L2, L3, L4 | Federation, search, cache lookup | Query planning, atlas/archive/publication/gene connectors, connector/result cache, source attribution, partial results, URI reconciliation. |
-| 08 Neuroscience Abstract Atlas | L0, L1, L2, L3, L4, L5 | Search, drill-down, LLM-assisted query | Corpus ingest with DOI/OpenAlex/ORCID linkage, configurable embedding backends, UMAP and community-detection clustering, cluster labelling, landscape UI with lens switching, atlas release manifests, [Future] citation/trend/gap overlays and MCP endpoint. |
+| 08 Neuroscience Abstract Atlas | L0, L1, L2, L3, L4, L5 | Search, drill-down, LLM-assisted query | Corpus ingest with DOI/OpenAlex/ORCID linkage, configurable embedding backends, UMAP and community-detection clustering, cluster labeling, landscape UI with lens switching, atlas release manifests, [Future] citation/trend/gap overlays and MCP endpoint. |
 | 09 Grounded Assistant | L1, L2, L3, L4 | LLM-assisted query, search, memory retrieval | pgvector retrieval, cache-aware graph hydration, scoped memory, citations to claims/assets/papers, provider boundary, fallback behavior. |
 
 ## Contract Traceability Matrix

--- a/design/brainkb-architecture.md
+++ b/design/brainkb-architecture.md
@@ -1134,7 +1134,7 @@ Resources are tangible things with identifiers — datasets, tools, models, pipe
 
 ### Epic 08 - Neuroscience Abstract Atlas
 
-The abstract atlas is a meta-scientific layer over publication corpora — papers, preprints, and conference abstracts — that complements the entity graph with a topical map of how the field is organized. It is informed by the [sensein/ohbm2026](https://github.com/sensein/ohbm2026) pipeline (conference-scale corpus, embeddings, UMAP, community-detection clusters, faceted UI) and by [Costa et al., *The Evolving Landscape of Neuroscience*](https://apertureneuro.org/article/156380-the-evolving-landscape-of-neuroscience) (field-scale longitudinal map of ~460k PubMed abstracts, contrastive-learned embedding space, Leiden clusters, citation overlays).
+The abstract atlas is a meta-scientific layer over publication corpora — papers, preprints, and conference abstracts — that complements the entity graph with a topical map of how the field is organized. It is informed by the [sensein/ohbm2026](https://github.com/sensein/ohbm2026) pipeline (conference-scale corpus, embeddings, UMAP, community-detection clusters, faceted UI) and by [Senden, *The Evolving Landscape of Neuroscience*](https://apertureneuro.org/article/156380-the-evolving-landscape-of-neuroscience) (field-scale longitudinal map of ~460k PubMed abstracts, contrastive-learned embedding space, Leiden clusters, citation overlays).
 
 **Actor:** researcher
 


### PR DESCRIPTION
## Summary

Adds a new epic — **Epic 08: Neuroscience Abstract Atlas** — to the BrainKB architecture design document. The atlas is a meta-scientific layer over publication corpora (papers, preprints, conference abstracts) that complements the entity graph with a topical map of how the field is organized.

The epic is grounded in two prior bodies of work:

- [`sensein/ohbm2026`](https://github.com/sensein/ohbm2026) — a conference-scale pipeline that ingests abstracts, generates embeddings (MiniLM / OpenAI / Voyage), runs UMAP + community-detection + k-means clustering, and serves a faceted/semantic-search UI with cluster pages.
- [Costa et al., *The Evolving Landscape of Neuroscience* (Aperture Neuro)](https://apertureneuro.org/article/156380-the-evolving-landscape-of-neuroscience) — a field-scale longitudinal map of ~460k PubMed abstracts using a contrastive-learned embedding space, Leiden clusters, and citation overlays to identify trends, cross-cluster influence, and gaps.

The epic complements Epic 01 (entity exploration — "what do we know about *this thing*") by answering "what does the field *look like*", and is positioned to feed cluster context into search ranking, hypothesis suggestions, and grounded-assistant retrieval.

## Changes

- Added use-case row 08 to the Use Cases table in Part 1.
- Added "Neuroscience Abstract Atlas" to the bulleted epics list in Part 6.
- Added the full **Epic 08** section after Epic 07 (actor, goal, value, trigger, preconditions, acceptance criteria, implementation sequencing) with `[Future]` markers for deferred items.
- Added an Epic 08 row to the Traceability Matrix.

## Test plan

- [ ] Markdown renders correctly (anchors, tables, link targets).
- [ ] Anchor `#epic-08---neuroscience-abstract-atlas` is reachable from both the use-case table and the epics list.
- [ ] Confirm the proposed scope, preconditions, and sequencing match how the team wants the OHBM 2026 pipeline and the Aperture Neuro approach to be folded into BrainKB.

## Notes / non-goals

- No architecture diagrams (L0–L5) were modified. The atlas reuses existing actors (researcher, agent), the existing ingest path, and the existing vector/cache strategy. If the team wants explicit L2/L3 representation for atlas artifacts and lens switching, that can be a follow-up.
- The pre-existing `09 Grounded Assistant` row in the Traceability Matrix looks like a leftover from the recent renumbering (Epic 05 already covers "Grounded Assistant / MCP Interface"). Left untouched here to keep this PR focused on the new epic.

---
_Generated by [Claude Code](https://claude.ai/code/session_016AnNGoEshRcytzbeKSNSk9)_